### PR TITLE
Many small updates and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.swp
 *.o
 pairhmm
+test_data/

--- a/makefile
+++ b/makefile
@@ -9,4 +9,4 @@ clean:
 	$(MAKE) -C $(CODE_DIR) clean
 
 check:
-	valgrind --leak-check=yes ./pairhmm test_data/tiny.in
+	valgrind --leak-check=yes ./pairhmm test_data/tiny.in > /dev/null

--- a/src/constants.h
+++ b/src/constants.h
@@ -1,14 +1,14 @@
 #ifndef __CONSTANTS__
 #define __CONSTANTS__
 
-template<class Precision>
+template<class PRECISION>
 struct Constants {
-  Precision mm;
-  Precision gm;
-  Precision mx;
-  Precision xx;
-  Precision my;
-  Precision yy;
+  PRECISION mm;
+  PRECISION gm;
+  PRECISION mx;
+  PRECISION xx;
+  PRECISION my;
+  PRECISION yy;
 };
 
 #endif

--- a/src/diagonals.cpp
+++ b/src/diagonals.cpp
@@ -4,8 +4,8 @@
 
 using namespace std;
 
-template<class Precision>
-ostream& operator<<(ostream& out, const Diagonals<Precision>& diagonals) {
+template<class PRECISION>
+ostream& operator<<(ostream& out, const Diagonals<PRECISION>& diagonals) {
   out << "M   -> "; for (auto x : diagonals.m) out << x << ","; out << endl;
   out << "Mp  -> "; for (auto x : diagonals.mp) out << x << ","; out << endl;
   out << "Mpp -> "; for (auto x : diagonals.mpp) out << x << ","; out << endl;

--- a/src/diagonals.h
+++ b/src/diagonals.h
@@ -4,29 +4,29 @@
 #include <vector>
 #include <iostream>
 
-template<class Precision>
+template<class PRECISION>
 struct Diagonals {
-  std::vector<Precision> m;
-  std::vector<Precision> mp;
-  std::vector<Precision> mpp;
-  std::vector<Precision> x;
-  std::vector<Precision> xp;
-  std::vector<Precision> xpp;
-  std::vector<Precision> y;
-  std::vector<Precision> yp;
-  std::vector<Precision> ypp;
+  std::vector<PRECISION> m;
+  std::vector<PRECISION> mp;
+  std::vector<PRECISION> mpp;
+  std::vector<PRECISION> x;
+  std::vector<PRECISION> xp;
+  std::vector<PRECISION> xpp;
+  std::vector<PRECISION> y;
+  std::vector<PRECISION> yp;
+  std::vector<PRECISION> ypp;
 
   Diagonals() = default;
   Diagonals(const size_t read_length) :
-    m   (read_length, static_cast<Precision>(0)),
-    mp  (read_length, static_cast<Precision>(0)),
-    mpp (read_length, static_cast<Precision>(0)),
-    x   (read_length, static_cast<Precision>(0)),
-    xp  (read_length, static_cast<Precision>(0)),
-    xpp (read_length, static_cast<Precision>(0)),
-    y   (read_length, static_cast<Precision>(0)),
-    yp  (read_length, static_cast<Precision>(0)),
-    ypp (read_length, static_cast<Precision>(0))
+    m   (read_length, static_cast<PRECISION>(0)),
+    mp  (read_length, static_cast<PRECISION>(0)),
+    mpp (read_length, static_cast<PRECISION>(0)),
+    x   (read_length, static_cast<PRECISION>(0)),
+    xp  (read_length, static_cast<PRECISION>(0)),
+    xpp (read_length, static_cast<PRECISION>(0)),
+    y   (read_length, static_cast<PRECISION>(0)),
+    yp  (read_length, static_cast<PRECISION>(0)),
+    ypp (read_length, static_cast<PRECISION>(0))
   {}
 
   void resize(const size_t new_size) {
@@ -38,9 +38,9 @@ struct Diagonals {
   }
 
   void zero() {
-    std::fill(m.begin(), m.end(), static_cast<Precision>(0)); std::fill(mp.begin(), mp.end(), static_cast<Precision>(0)); std::fill(mpp.begin(), mpp.end(), static_cast<Precision>(0));
-    std::fill(x.begin(), x.end(), static_cast<Precision>(0)); std::fill(xp.begin(), xp.end(), static_cast<Precision>(0)); std::fill(xpp.begin(), xpp.end(), static_cast<Precision>(0));
-    std::fill(y.begin(), y.end(), static_cast<Precision>(0)); std::fill(yp.begin(), yp.end(), static_cast<Precision>(0)); std::fill(ypp.begin(), ypp.end(), static_cast<Precision>(0));
+    std::fill(m.begin(), m.end(), static_cast<PRECISION>(0)); std::fill(mp.begin(), mp.end(), static_cast<PRECISION>(0)); std::fill(mpp.begin(), mpp.end(), static_cast<PRECISION>(0));
+    std::fill(x.begin(), x.end(), static_cast<PRECISION>(0)); std::fill(xp.begin(), xp.end(), static_cast<PRECISION>(0)); std::fill(xpp.begin(), xpp.end(), static_cast<PRECISION>(0));
+    std::fill(y.begin(), y.end(), static_cast<PRECISION>(0)); std::fill(yp.begin(), yp.end(), static_cast<PRECISION>(0)); std::fill(ypp.begin(), ypp.end(), static_cast<PRECISION>(0));
   }
 
   void rotate() {
@@ -54,7 +54,7 @@ struct Diagonals {
     
 };
 
-template<class Precision>
-std::ostream& operator<<(std::ostream& out, const Diagonals<Precision>& diagonals); 
+template<class PRECISION>
+std::ostream& operator<<(std::ostream& out, const Diagonals<PRECISION>& diagonals); 
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,9 +9,8 @@
 
 using namespace std;
 
-
 int main (const int argc, char const * const argv[]) {
-  auto pairhmm = Pairhmm<float>{};
+  auto pairhmm = Pairhmm{};
   InputReader<TestcaseIterator> reader {};
   if (argc == 2) 
     reader.from_file(argv[1]);

--- a/src/makefile
+++ b/src/makefile
@@ -1,6 +1,6 @@
 CXXFLAGS=-c -Wall -std=c++11 -g -o0
 LDFLAGS=
-SOURCES= testcase.cpp testcase_iterator.cpp haplotype.cpp main.cpp diagonals.cpp
+SOURCES= testcase.cpp testcase_iterator.cpp haplotype.cpp main.cpp diagonals.cpp pairhmm.cpp
 OBJECTS=$(SOURCES:.cpp=.o)
 EXECUTABLE=../pairhmm
 

--- a/src/pairhmm.cpp
+++ b/src/pairhmm.cpp
@@ -1,0 +1,13 @@
+#include <vector>
+#include <limits>
+
+#include "pairhmm.h"
+#include "testcase.h"
+
+using namespace std;
+
+vector<double> Pairhmm::calculate(const Testcase& testcase) {
+  auto results = phmm_float.calculate(testcase);  // calculate all the testcases using the float precision pairhmm implementation
+  phmm_double.recalculate(testcase, results, phmm_float.max_original_read_length, phmm_float.max_padded_read_length); // recalculate only the ones that failed with double precision (results = DOUBLE_MIN for failed ones)
+  return results;
+}

--- a/src/pairhmm.h
+++ b/src/pairhmm.h
@@ -1,180 +1,18 @@
 #ifndef __PAIRHMM__
 #define __PAIRHMM__
+
 #include <vector>
-#include <cmath>
-#include <algorithm>
-#include <ostream>
 
+#include "pairhmm_impl.h"
 #include "testcase.h"
-#include "constants.h"
-#include "diagonals.h"
 
-template <class Precision>
 class Pairhmm {
- private:
-  std::vector<Constants<Precision>> constants;
-  Diagonals<Precision> diagonals;
-  std::vector<Precision> ph2pr;
+  private:
+    PairhmmImpl<float> phmm_float;
+    PairhmmImpl<double> phmm_double;
 
-  static constexpr auto MAX_PH2PR_INDEX = 128;
-  static constexpr auto INITIAL_CONSTANT = 1e32f;
-  static constexpr auto INITIAL_SIZE = 250;
-
-  template<class T>
-  void pad (T& v, size_t padding) const {
-    while(padding-- > 0)
-      v.push_back(0);
-  }
-
-  Haplotype pad_and_reverse_haplotype(const Haplotype& haplotype, const size_t left_padding, const size_t right_padding) const {
-    const auto total_padding = left_padding + haplotype.bases.size() + right_padding;
-    auto p = Haplotype{};
-    p.original_length = haplotype.bases.size();  
-    p.bases.reserve(total_padding);
-    pad(p.bases, left_padding);
-    for (auto i = haplotype.bases.rbegin(); i != haplotype.bases.rend(); ++i)
-      p.bases.push_back(*i);
-    pad(p.bases, right_padding);
-    return p;
-  }
-
-  const Haplotype pad_haplotype(const Haplotype& haplotype, const uint32_t read_length) const {
-    const auto left_padding = read_length + 1;
-    const auto right_padding = read_length;
-    const auto padded_haplotype = pad_and_reverse_haplotype(haplotype, left_padding, right_padding);
-    return padded_haplotype;
-  }
-
-  template<class Result_Type>
-  std::vector<Result_Type> pad_and_convert_qual(const std::vector<uint8_t>& qual, const size_t left_padding, const size_t right_padding = 0, const bool convert = true) const {
-    const auto total_padding = left_padding + qual.size() + right_padding;
-    auto p = std::vector<Result_Type>{};
-    p.reserve(total_padding);
-    pad(p, left_padding);
-    for (const auto q : qual)
-      p.push_back(convert ? ph2pr[q] : q);
-    pad(p, right_padding);
-    return p;
-  }
-
-  Read<Precision> pad_read(const Read<uint8_t>& read) const {
-    const auto left_padding = 1;
-    auto padded_read = Read<Precision>{};
-    padded_read.original_length = read.bases.size();
-    padded_read.bases      = pad_and_convert_qual<uint8_t>(read.bases, left_padding, 0, false);
-    padded_read.base_quals = pad_and_convert_qual<Precision>(read.base_quals, left_padding);
-    padded_read.ins_quals  = pad_and_convert_qual<Precision>(read.ins_quals, left_padding);
-    padded_read.del_quals  = pad_and_convert_qual<Precision>(read.del_quals, left_padding);
-    padded_read.gcp_quals  = pad_and_convert_qual<Precision>(read.gcp_quals, left_padding);
-    return padded_read;
-  }
-
-  std::vector<Read<Precision>> pad_reads(std::vector<Read<uint8_t>>& reads) const {
-    auto padded_reads = std::vector<Read<Precision>>{};
-    for (auto& read : reads) 
-      padded_reads.push_back(pad_read(read));
-    return padded_reads;
-  }
-
-  std::vector<Haplotype> pad_haplotypes(const std::vector<Haplotype>& haplotypes, const size_t max_read_length) const {
-    auto padded_haplotypes = std::vector<Haplotype>{};
-    padded_haplotypes.reserve(haplotypes.size());
-    for (const auto& haplotype : haplotypes) 
-      padded_haplotypes.push_back(pad_haplotype(haplotype, max_read_length));
-    return padded_haplotypes;
-  }
-
-  template <class T>
-  size_t calculate_max_read_length(const std::vector<Read<T>>& reads) const {
-    auto max_read_length = 0u;
-    for (const auto& read : reads)
-      max_read_length = max_read_length >= read.bases.size() ? max_read_length : read.bases.size();
-    return max_read_length;
-  }
-
-  void resize_constants(const size_t new_size) {
-    if (constants.capacity() < new_size) 
-      constants.resize(new_size);
-  }
-
-  void update_constants(const Read<Precision>& read) {
-    const auto rows = read.bases.size();
-    for (auto i = 1u; i != rows; ++i) {
-      constants[i].mm = static_cast<Precision>(1) - (read.ins_quals[i] + read.del_quals[i]);
-      constants[i].gm = static_cast<Precision>(1) - read.gcp_quals[i];
-      constants[i].mx = read.ins_quals[i];
-      constants[i].xx = read.gcp_quals[i];
-      constants[i].my = i < (rows - 1) ? read.del_quals[i] : static_cast<Precision>(1);
-      constants[i].yy = i < (rows - 1) ? read.gcp_quals[i] : static_cast<Precision>(1);
-    }
-  }
-
-  void update_diagonals(const Haplotype& hap) {
-    diagonals.zero();
-    const auto first_row_value = INITIAL_CONSTANT / hap.original_length;
-    diagonals.ypp[0] = diagonals.yp[0] = diagonals.y[0] = first_row_value;
-  }
-
-  inline Precision calculate_prior(const char read_base, const char hap_base, const Precision base_qual) const {
-    return  ((read_base == hap_base) || (read_base == 'N') || (hap_base == 'N')) ? 
-      static_cast<Precision>(1) - base_qual : 
-      base_qual;
-  }
-
-  double compute_full_prob(const Read<Precision>& read, const Haplotype& haplotype) {
-    const auto rows = read.bases.size();
-    const auto rl = read.original_length;
-    const auto hl = haplotype.original_length;
-    auto result = 0.l;
-    for (auto d = 0u; d != rl + hl - 1; ++d) {  // d for diagonal
-      for (auto r = 1u; r != rows; ++r) {  // r for row
-        auto hap_idx = rl+hl-d+r-1;
-        auto read_base = read.bases[r];
-        auto hap_base = haplotype.bases[hap_idx];
-        auto prior = calculate_prior(read_base, hap_base, read.base_quals[r]);
-        diagonals.m[r] = prior * ((diagonals.mpp[r-1] * constants[r].mm) + (constants[r].gm * (diagonals.xpp[r-1] + diagonals.ypp[r-1])));
-        diagonals.x[r] = diagonals.mp[r-1] * constants[r].mx + diagonals.xp[r-1] * constants[r].xx; 
-        diagonals.y[r] = diagonals.mp[r] * constants[r].my + diagonals.yp[r] * constants[r].yy; 
-      }
-      result += diagonals.m[rows-1] + diagonals.x[rows-1];
-      diagonals.rotate();
-    }
-    return log10(static_cast<double>(result)) - log10(static_cast<double>(INITIAL_CONSTANT));
-  }
-
-  std::vector<double> calculate (const std::vector<Read<Precision>>& padded_reads, const std::vector<Haplotype>& padded_haplotypes) {
-    auto results = std::vector<double>{};
-    for (const auto& read : padded_reads) {
-      update_constants(read);
-      for (const auto& hap : padded_haplotypes) {
-        update_diagonals(hap);
-        results.push_back(compute_full_prob(read, hap));
-      }
-    }
-    return results;
-  }
-
- public:
-
-  Pairhmm(const size_t initial_size = INITIAL_SIZE) :
-    constants {initial_size},
-    diagonals {initial_size},
-    ph2pr{}
-  {
-    for (auto i=static_cast<Precision>(0); i!=MAX_PH2PR_INDEX; ++i) 
-      ph2pr.push_back(pow(static_cast<Precision>(10.0), (-i) / static_cast<Precision>(10.0))); 
-  }
-
-  std::vector<double> calculate (Testcase& testcase) {
-    const auto max_original_read_length = calculate_max_read_length(testcase.reads);
-    const auto padded_haplotypes = pad_haplotypes(testcase.haplotypes, max_original_read_length);
-    const auto padded_reads = pad_reads(testcase.reads);
-    const auto max_padded_read_length = calculate_max_read_length(padded_reads);
-    resize_constants(max_padded_read_length);
-    diagonals.resize(max_padded_read_length);
-    return calculate(padded_reads, padded_haplotypes);
-  }
-
+  public: 
+    std::vector<double> calculate(const Testcase& testcase);
 };
 
 #endif

--- a/src/pairhmm_impl.h
+++ b/src/pairhmm_impl.h
@@ -1,0 +1,273 @@
+#ifndef __PAIRHMM_IMPL__
+#define __PAIRHMM_IMPL__
+
+#include <vector>
+#include <cmath>
+#include <algorithm>
+#include <ostream>
+#include <unordered_map>
+#include <cassert>
+
+#include "testcase.h"
+#include "constants.h"
+#include "diagonals.h"
+
+#define P(x) x 
+
+namespace constants_with_precision {
+  template <class T>
+  static constexpr T INITIAL_CONSTANT_WITH_PRECISION();
+
+  template <>
+  constexpr double INITIAL_CONSTANT_WITH_PRECISION<double>() {return std::numeric_limits<double>::max() / 16;}
+
+  template <>
+  constexpr float INITIAL_CONSTANT_WITH_PRECISION<float>() {return std::numeric_limits<float>::max() / 16;}
+
+  template <class T>
+  static constexpr T MIN_ACCEPTED_WITH_PRECISION();
+
+  template <>
+  constexpr double MIN_ACCEPTED_WITH_PRECISION<double>() {return 0.l;}
+
+  template <>
+  constexpr float MIN_ACCEPTED_WITH_PRECISION<float>() {return 1e-28f;}
+}
+
+template <class PRECISION>
+class PairhmmImpl {
+
+ public:
+  size_t max_original_read_length = 0;  // updated during calculate()
+  size_t max_padded_read_length = 0;    // updated during calculate()
+
+  PairhmmImpl(const size_t initial_size = INITIAL_SIZE) :
+    constants {initial_size},
+    diagonals {initial_size},
+    ph2pr{} {
+    for (auto i=static_cast<PRECISION>(0); i!=MAX_PH2PR_INDEX; ++i) 
+      ph2pr.push_back(pow(static_cast<PRECISION>(10.0), (-i) / static_cast<PRECISION>(10.0))); 
+  }
+
+  std::vector<double> calculate (const Testcase& testcase) {
+    max_original_read_length = calculate_max_read_length(testcase.reads);
+    const auto padded_haplotypes = pad_haplotypes(testcase.haplotypes);
+    const auto padded_reads = pad_reads(testcase.reads);
+    max_padded_read_length = calculate_max_read_length(padded_reads);
+    resize_constants(max_padded_read_length);
+    diagonals.resize(max_padded_read_length);
+    return calculate(padded_reads, padded_haplotypes);
+  }
+
+  void recalculate (const Testcase& testcase, std::vector<double>& results, const size_t max_original_read_length_, const size_t max_padded_read_length_) {
+    max_original_read_length = max_original_read_length_;
+    max_padded_read_length = max_padded_read_length_;
+    auto padded_pairs = std::vector<IndexedPair>{};
+    padded_pairs.reserve(results.size());
+    auto padded_read_cache = std::unordered_map<uint32_t, Read<PRECISION>>{};
+    padded_read_cache.reserve(testcase.reads.size());
+    auto padded_haplotype_cache = std::unordered_map<uint32_t, Haplotype>{};
+    padded_haplotype_cache.reserve(testcase.haplotypes.size());
+    auto master_idx = 0u;
+    for (auto r : results) {
+      if (r == FAILED_RUN_RESULT) {
+        const auto read_idx = master_idx / testcase.haplotypes.size();
+        const auto hap_idx = master_idx % testcase.haplotypes.size();
+        const auto& padded_read = from_cache(padded_read_cache, read_idx, testcase.reads[read_idx]);
+        const auto& padded_haplotype = from_cache(padded_haplotype_cache, hap_idx, testcase.haplotypes[hap_idx]);
+        padded_pairs.emplace_back(master_idx, &padded_read, &padded_haplotype);
+      }
+      ++master_idx;
+    }
+    recalculate(padded_pairs, results, testcase.haplotypes.size());
+  }
+
+
+
+ private:
+  std::vector<Constants<PRECISION>> constants;
+  Diagonals<PRECISION> diagonals;
+  std::vector<PRECISION> ph2pr;
+
+  static constexpr auto MAX_PH2PR_INDEX = 128;
+  static constexpr auto INITIAL_CONSTANT = constants_with_precision::INITIAL_CONSTANT_WITH_PRECISION<PRECISION>();
+  static constexpr auto INITIAL_SIZE = 250;
+  static constexpr auto MIN_ACCEPTED = constants_with_precision::MIN_ACCEPTED_WITH_PRECISION<PRECISION>();  
+  static constexpr auto FAILED_RUN_RESULT = std::numeric_limits<double>::min();
+
+  struct IndexedPair {
+    const uint32_t index;
+    const Read<PRECISION> * const read;
+    const Haplotype * const haplotype;
+
+    IndexedPair(const uint32_t index_, const Read<PRECISION> * const read_, const Haplotype * const haplotype_) :
+      index{index_},
+      read{read_},
+      haplotype{haplotype_}
+    {}
+  };
+
+  template<class T>
+  void pad (T& v, size_t padding) const {
+    v.insert(v.end(), padding, 0);
+  }
+
+  Haplotype pad_and_reverse_haplotype(const Haplotype& haplotype, const size_t left_padding, const size_t right_padding) const {
+    const auto padded_length = left_padding + haplotype.bases.size() + right_padding;
+    auto p = Haplotype{};
+    p.original_length = haplotype.bases.size();  
+    p.bases.reserve(padded_length);
+    pad(p.bases, left_padding);
+    p.bases.insert(p.bases.end(), haplotype.bases.rbegin(), haplotype.bases.rend());
+    pad(p.bases, right_padding);
+    return p;
+  }
+
+  const Haplotype pad_haplotype(const Haplotype& haplotype) const {
+    const auto left_padding = max_original_read_length + 1;
+    const auto right_padding = max_original_read_length;
+    return pad_and_reverse_haplotype(haplotype, left_padding, right_padding);
+  }
+
+  template<class Result_Type, const bool convert = true>
+  std::vector<Result_Type> pad_and_convert_qual(const std::vector<uint8_t>& qual, const size_t left_padding, const size_t right_padding = 0) const {
+    const auto padded_length = left_padding + qual.size() + right_padding;
+    auto p = std::vector<Result_Type>{};
+    p.reserve(padded_length);
+    pad(p, left_padding);
+    for (const auto q : qual)
+      p.push_back(convert ? ph2pr[q] : q);
+    pad(p, right_padding);
+    return p;
+  }
+
+  Read<PRECISION> pad_read(const Read<uint8_t>& read) const {
+    const auto left_padding = 1;
+    auto padded_read = Read<PRECISION>{};
+    padded_read.original_length = read.bases.size();
+    padded_read.bases      = pad_and_convert_qual<uint8_t, false>(read.bases, left_padding);
+    padded_read.base_quals = pad_and_convert_qual<PRECISION>(read.base_quals, left_padding);
+    padded_read.ins_quals  = pad_and_convert_qual<PRECISION>(read.ins_quals, left_padding);
+    padded_read.del_quals  = pad_and_convert_qual<PRECISION>(read.del_quals, left_padding);
+    padded_read.gcp_quals  = pad_and_convert_qual<PRECISION>(read.gcp_quals, left_padding);
+    return padded_read;
+  }
+
+  std::vector<Read<PRECISION>> pad_reads(const std::vector<Read<uint8_t>>& reads) const {
+    auto padded_reads = std::vector<Read<PRECISION>>{};
+    padded_reads.reserve(reads.size());
+    for (auto& read : reads) 
+      padded_reads.push_back(pad_read(read));
+    return padded_reads;
+  }
+
+  std::vector<Haplotype> pad_haplotypes(const std::vector<Haplotype>& haplotypes) const {
+    auto padded_haplotypes = std::vector<Haplotype>{};
+    padded_haplotypes.reserve(haplotypes.size());
+    for (const auto& haplotype : haplotypes) 
+      padded_haplotypes.push_back(pad_haplotype(haplotype));
+    return padded_haplotypes;
+  }
+
+  template <class T>
+  size_t calculate_max_read_length(const std::vector<Read<T>>& reads) const {
+    auto max_read_length = 0u;
+    for (const auto& read : reads)
+      max_read_length = max_read_length >= read.bases.size() ? max_read_length : read.bases.size();
+    return max_read_length;
+  }
+
+  void resize_constants(const size_t new_size) {
+    if (constants.capacity() < new_size) 
+      constants.resize(new_size);
+  }
+
+  void update_constants(const Read<PRECISION>& read) {
+    const auto rows = read.bases.size();
+    for (auto i = 1u; i != rows; ++i) {
+      constants[i].mm = static_cast<PRECISION>(1) - (read.ins_quals[i] + read.del_quals[i]);
+      constants[i].gm = static_cast<PRECISION>(1) - read.gcp_quals[i];
+      constants[i].mx = read.ins_quals[i];
+      constants[i].xx = read.gcp_quals[i];
+      constants[i].my = i < (rows - 1) ? read.del_quals[i] : static_cast<PRECISION>(1);
+      constants[i].yy = i < (rows - 1) ? read.gcp_quals[i] : static_cast<PRECISION>(1);
+    }
+  }
+
+  void update_diagonals(const Haplotype& hap) {
+    diagonals.zero();
+    const auto first_row_value = INITIAL_CONSTANT / hap.original_length;
+    diagonals.ypp[0] = diagonals.yp[0] = diagonals.y[0] = first_row_value;
+  }
+
+  inline PRECISION calculate_prior(const char read_base, const char hap_base, const PRECISION base_qual) const {
+    return  ((read_base == hap_base) || (read_base == 'N') || (hap_base == 'N')) ? 
+      static_cast<PRECISION>(1) - base_qual : 
+      base_qual;
+  }
+
+  double compute_full_prob(const Read<PRECISION>& read, const Haplotype& haplotype) {
+    const auto rows = read.bases.size();        // number of rows in the diagonals (padded read length)
+    const auto hl = haplotype.original_length;  // haplotype original length (unpadded)
+    const auto rl = read.original_length;       // read original length (unpadded)
+    const auto mrl = max_original_read_length;  // alias for max original read length for readability in the code below (max read length in the testcase)
+    const auto fd = mrl - rl;                   // first diagonal to compute (saves compute of all-0 diagonals when read is shorter than the padding - which will be the maximum read length in the testcase)
+    auto result = 0.l;                          // result accumulator
+    for (auto d = fd; d != mrl + hl - 1; ++d) { // d for diagonal
+      for (auto r = 1u; r != rows; ++r) {       // r for row
+        const auto hap_idx = mrl+hl-d+r-1;
+        const auto read_base = read.bases[r];
+        const auto hap_base = haplotype.bases[hap_idx];
+        const auto prior = calculate_prior(read_base, hap_base, read.base_quals[r]);
+        diagonals.m[r] = prior * ((diagonals.mpp[r-1] * constants[r].mm) + (constants[r].gm * (diagonals.xpp[r-1] + diagonals.ypp[r-1])));
+        diagonals.x[r] = diagonals.mp[r-1] * constants[r].mx + diagonals.xp[r-1] * constants[r].xx; 
+        diagonals.y[r] = diagonals.mp[r] * constants[r].my + diagonals.yp[r] * constants[r].yy; 
+      }
+      result += diagonals.m[rows-1] + diagonals.x[rows-1];
+      diagonals.rotate();
+    }
+    return result < MIN_ACCEPTED ? 
+      FAILED_RUN_RESULT :                       // if we underflowed return failed constant to rerun with higher precision if desired
+      log10(static_cast<double>(result)) - log10(static_cast<double>(INITIAL_CONSTANT));
+  }
+
+  std::vector<double> calculate (const std::vector<Read<PRECISION>>& padded_reads, const std::vector<Haplotype>& padded_haplotypes) {
+    auto results = std::vector<double>{};
+    results.reserve(padded_reads.size() * padded_haplotypes.size());
+    for (const auto& read : padded_reads) {
+      update_constants(read);
+      for (const auto& hap : padded_haplotypes) {
+        update_diagonals(hap);
+        results.push_back(compute_full_prob(read, hap));
+      }
+    }
+    return results;
+  }
+
+  void recalculate (const std::vector<IndexedPair>& padded_pairs, std::vector<double>& results, const size_t n_haplotypes) {
+    auto last_read_idx = -1;
+    for (const auto& pp : padded_pairs) {
+      auto read_idx = pp.index / n_haplotypes;
+      if (read_idx != last_read_idx) 
+        update_constants(*pp.read);    // only update if this is a new read (reads come in sorted)! 
+      update_diagonals(*pp.haplotype); // should always update
+      results[pp.index] = compute_full_prob(*pp.read, *pp.haplotype);
+      last_read_idx = read_idx;
+    }
+  }
+
+  const Read<PRECISION>& from_cache(std::unordered_map<uint32_t, Read<PRECISION>>& cache, const uint32_t index, const Read<uint8_t>& original) {
+    if (cache.count(index) == 0) 
+      cache.emplace(index, pad_read(original));
+    return cache.at(index);
+  }
+
+  const Haplotype& from_cache(std::unordered_map<uint32_t, Haplotype>& cache, const uint32_t index, const Haplotype& original) {
+    if (cache.count(index) == 0) 
+      cache.emplace(index, pad_haplotype(original));
+    return cache.at(index);
+  }
+
+};
+
+#endif


### PR DESCRIPTION
- make testcase const and use insert instead of push_backs
- make template parameters all uppercase
- rerun failed tests (underflow) with double precision
- ignore the test_data directory, to modify/add files there you need to use --force. This is to make it difficult for people to add big test files to the repo
- skip all-zero diagonals in cases when read is smaller than the longest read in the testcase
- fixed padding bug where compute_full_prob was using read_length instead of max_original_read_length in testcases where read lengths were variable
