### PR TITLE
Simplify API before SSE implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: cpp
 compiler: gcc
-script: make
+script: 
+  - make clean
+  - make test
 before_script:
-    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test 
-    - sudo apt-get -qq update
-    - sudo apt-get -qq install g++-4.8 valgrind
-    - export CXX="g++-4.8" 
-after_script: make check
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test 
+  - sudo apt-get -qq update
+  - sudo apt-get -qq install g++-4.8 valgrind
+  - export CXX="g++-4.8" 
+after_script: 
+  - make check

--- a/makefile
+++ b/makefile
@@ -8,8 +8,8 @@ project_code:
 clean:
 	$(MAKE) -C $(CODE_DIR) clean
 
-test:
-	$(MAKE) -C $(CODE_DIR) test
+test: project_code
+	@./pairhmm < test_data/tiny.in | paste - test_data/tiny.out  | awk 'BEGIN {m = 0; n = NR} {a = $$2-$$1; a = a < 0? -a: a; if (a > m) {m = a; n = NR} } END { printf("max error %g at line %d\n", m, n)} '
 
 check:
 	valgrind --leak-check=yes ./pairhmm test_data/tiny.in > /dev/null

--- a/src/constants.h
+++ b/src/constants.h
@@ -1,14 +1,50 @@
 #ifndef __CONSTANTS__
 #define __CONSTANTS__
 
+#include <vector> 
+
+#include "read.h"
+
+namespace constants_impl {
+
+template<class PRECISION>
+  struct Constants {
+    PRECISION mm;
+    PRECISION gm;
+    PRECISION mx;
+    PRECISION xx;
+    PRECISION my;
+    PRECISION yy;
+  };
+
+}
+
 template<class PRECISION>
 struct Constants {
-  PRECISION mm;
-  PRECISION gm;
-  PRECISION mx;
-  PRECISION xx;
-  PRECISION my;
-  PRECISION yy;
+  std::vector<constants_impl::Constants<PRECISION>> index;
+
+  Constants(const std::size_t initial_size) :
+    index(initial_size) 
+  {}
+
+  void resize(const std::size_t new_size) {
+    if (index.capacity() < new_size) 
+      index.resize(new_size);
+  }
+
+  void update(const Read<PRECISION>& read) {
+    const auto rows = read.bases.size();
+    for (auto i = 1u; i != rows; ++i) {
+      index[i].mm = static_cast<PRECISION>(1) - (read.ins_quals[i] + read.del_quals[i]);
+      index[i].gm = static_cast<PRECISION>(1) - read.gcp_quals[i];
+      index[i].mx = read.ins_quals[i];
+      index[i].xx = read.gcp_quals[i];
+      index[i].my = i < (rows - 1) ? read.del_quals[i] : static_cast<PRECISION>(1);
+      index[i].yy = i < (rows - 1) ? read.gcp_quals[i] : static_cast<PRECISION>(1);
+    }
+  }
+
 };
+
 
 #endif

--- a/src/diagonals.h
+++ b/src/diagonals.h
@@ -37,12 +37,6 @@ struct Diagonals {
     }
   }
 
-  void zero() {
-    std::fill(m.begin(), m.end(), static_cast<PRECISION>(0)); std::fill(mp.begin(), mp.end(), static_cast<PRECISION>(0)); std::fill(mpp.begin(), mpp.end(), static_cast<PRECISION>(0));
-    std::fill(x.begin(), x.end(), static_cast<PRECISION>(0)); std::fill(xp.begin(), xp.end(), static_cast<PRECISION>(0)); std::fill(xpp.begin(), xpp.end(), static_cast<PRECISION>(0));
-    std::fill(y.begin(), y.end(), static_cast<PRECISION>(0)); std::fill(yp.begin(), yp.end(), static_cast<PRECISION>(0)); std::fill(ypp.begin(), ypp.end(), static_cast<PRECISION>(0));
-  }
-
   void rotate() {
     std::swap(mpp, mp);
     std::swap(xpp, xp);
@@ -52,6 +46,13 @@ struct Diagonals {
     std::swap(yp, y);
   }
     
+  void update(const PRECISION first_row_value) {
+    std::fill(m.begin(), m.end(), static_cast<PRECISION>(0)); std::fill(mp.begin(), mp.end(), static_cast<PRECISION>(0)); std::fill(mpp.begin(), mpp.end(), static_cast<PRECISION>(0));
+    std::fill(x.begin(), x.end(), static_cast<PRECISION>(0)); std::fill(xp.begin(), xp.end(), static_cast<PRECISION>(0)); std::fill(xpp.begin(), xpp.end(), static_cast<PRECISION>(0));
+    std::fill(y.begin(), y.end(), static_cast<PRECISION>(0)); std::fill(yp.begin(), yp.end(), static_cast<PRECISION>(0)); std::fill(ypp.begin(), ypp.end(), static_cast<PRECISION>(0));
+    ypp[0] = yp[0] = y[0] = first_row_value;
+  }
+
 };
 
 template<class PRECISION>

--- a/src/makefile
+++ b/src/makefile
@@ -9,14 +9,10 @@ all: $(SOURCES) $(EXECUTABLE)
 $(EXECUTABLE): $(OBJECTS)
 	$(CXX) $(LDFLAGS) $(OBJECTS) -o $@
 
-test: ../pairhmm
-	@../pairhmm < ../test_data/tiny.in | paste - ../test_data/tiny.out  | awk 'BEGIN {m = 0; n = NR} {a = $$2-$$1; a = a < 0? -a: a; if (a > m) {m = a; n = NR} } END { printf("max error %g at line %d\n", m, n)} '
-
 diagonals.o: diagonals.cpp diagonals.h
 haplotype.o: haplotype.cpp haplotype.h utils.h
 main.o: main.cpp input_reader.h testcase_iterator.h testcase.h read.h \
- utils.h haplotype.h pairhmm.h pairhmm_impl.h constants.h diagonals.h \
- pairhmm.hpp
+ utils.h haplotype.h pairhmm.h pairhmm_impl.h constants.h diagonals.h 
 testcase.o: testcase.cpp testcase.h read.h utils.h haplotype.h
 testcase_iterator.o: testcase_iterator.cpp testcase_iterator.h testcase.h \
  read.h utils.h haplotype.h

--- a/src/pairhmm.h
+++ b/src/pairhmm.h
@@ -8,13 +8,15 @@
 
 template <typename FAST, typename CORRECT>
 class Pairhmm {
-  private:
-    FAST fast;
-    CORRECT correct;
-  public:
-    std::vector<double> calculate(const Testcase& testcase);
+ private:
+  FAST fast;
+  CORRECT correct;
+ public:
+  std::vector<double> calculate(const Testcase& testcase) {
+    auto results = fast.calculate(testcase);  // calculate all the testcases using the float precision pairhmm implementation
+    correct.recalculate(testcase, results, fast.max_original_read_length, fast.max_padded_read_length, fast.get_padded_haplotypes()); // recalculate only the ones that failed with double precision (results = DOUBLE_MIN for failed ones)
+    return results;
+  }
 };
-
-#include "pairhmm.hpp"
 
 #endif

--- a/src/pairhmm.hpp
+++ b/src/pairhmm.hpp
@@ -1,6 +1,0 @@
-template <typename FAST, typename CORRECT>
-std::vector<double> Pairhmm<FAST,CORRECT>::calculate(const Testcase& testcase) {
-  auto results = fast.calculate(testcase);  // calculate all the testcases using the float precision pairhmm implementation
-  correct.recalculate(testcase, results, fast.max_original_read_length, fast.max_padded_read_length); // recalculate only the ones that failed with double precision (results = DOUBLE_MIN for failed ones)
-  return results;
-}

--- a/src/read.h
+++ b/src/read.h
@@ -16,7 +16,7 @@ struct Read {
   std::vector<QUAL_TYPE> del_quals;
   std::vector<QUAL_TYPE> gcp_quals;
 
-  Read() = default;
+  explicit Read() = default;
 
   Read(const std::vector<uint8_t>& bases_,
        const std::vector<QUAL_TYPE>& quals_,

--- a/src/testcase.h
+++ b/src/testcase.h
@@ -18,7 +18,7 @@ struct Testcase {
     haplotypes {std::move(haplotypes_)}
   {};  
 
-  uint32_t calculate_max_read_length() const;
+  size_t size() const {return haplotypes.size() * reads.size();}
 };
 
 std::ostream& operator<<(std::ostream& out, const Testcase& testcase); 


### PR DESCRIPTION
Remove .hpp implementations
Move update method inside diagonals and now unused zero() method
Move diagonals to it's own class with all relevant operations
Move constants to it's own class with all relevant operations
Make padded_reads a private member of PairhmmImpl
Move make test to top-level makefile
Add 'make test' to Travis automated ci

Although I fully appreciate the effort of reducing compilation time,
the hpp split is not reasonable. The hpp is not a compilable standalone
unit and coding in it is a nightmare (without syntax checking). We need
a better standard. For now, let's keep it all in the .h

Fixes #31
Fixes #27
Fixes #26
